### PR TITLE
misprint in "passocde" and "trasaction";

### DIFF
--- a/blackcatmq.js
+++ b/blackcatmq.js
@@ -161,7 +161,7 @@ BlackCatMQ.prototype.connect = function(socket, frame) {
             return stomp.ServerFrame.ERROR('connect error','passcode is required');    
         }
         
-        self.auth.authenticate(login, passocde, function(err, user) {
+        self.auth.authenticate(login, passcode, function(err, user) {
             if (err) {
                 return stomp.ServerFrame.ERROR('connect error','incorrect login or passcode');    
             }
@@ -375,8 +375,8 @@ BlackCatMQ.prototype.begin = function(socket, frame) {
         return stomp.ServerFrame.ERROR('invalid parameters','there is no header section');
     }
     
-    var trasaction = frame.header['transaction'];
-    if (!trasaction) {
+    var transaction = frame.header['transaction'];
+    if (!transaction) {
         return stomp.ServerFrame.ERROR('invalid parameters','there is no transaction argument');
     }
     
@@ -401,8 +401,8 @@ BlackCatMQ.prototype.commit = function(socket, frame) {
         return stomp.ServerFrame.ERROR('invalid parameters','there is no header section');
     }
 
-    var trasaction = frame.header['transaction'];
-    if (!trasaction) {
+    var transaction = frame.header['transaction'];
+    if (!transaction) {
         return stomp.ServerFrame.ERROR('invalid parameters','there is no transaction argument');
     }
     
@@ -427,8 +427,8 @@ BlackCatMQ.prototype.abort = function(socket, frame) {
         return stomp.ServerFrame.ERROR('invalid parameters','there is no header section');
     }
     
-    var trasaction = frame.header['transaction'];
-    if (!trasaction) {
+    var transaction = frame.header['transaction'];
+    if (!transaction) {
         return stomp.ServerFrame.ERROR('invalid parameters','there is no transaction argument');
     }
     

--- a/test/stomp-consumer.js
+++ b/test/stomp-consumer.js
@@ -10,7 +10,7 @@ var stomp_args = {
     host: 'localhost',
     debug: false,
     login: 'guest',
-    passcode: 'guest',
+    passcode: 'guest'
 };
 
 var client = new stomp.Stomp(stomp_args);
@@ -20,7 +20,7 @@ var client = new stomp.Stomp(stomp_args);
 // and dump it to the client.
 var headers = {
     destination: '/queue/test_stomp',
-    ack: 'client',
+    ack: 'client'
 //    'activemq.prefetchSize': '10'
 };
 

--- a/test/stomp-producer.js
+++ b/test/stomp-producer.js
@@ -15,7 +15,7 @@ var stomp_args = {
     host: 'localhost',
     debug: false,
     login: 'guest',
-    passcode: 'guest',
+    passcode: 'guest'
 }
 
 var client = new stomp.Stomp(stomp_args);


### PR DESCRIPTION
misprint in "passocde" and "trasaction"; implicitly declared global variable key; unneeded commas.
