### PR TITLE
Support for websockets and stomp v1.1

### DIFF
--- a/lib/stomp.js
+++ b/lib/stomp.js
@@ -44,7 +44,9 @@ Frame.prototype.toString = function () {
     var data = this.command.toUpperCase() + '\x0a';
     
     for (var key in this.header) {
-        data += key + ':' + this.header[key] + '\x0a';
+        if(this.header[key] !== undefined) {
+            data += key + ':' + this.header[key] + '\x0a';
+        }
     }
     
     data += '\x0a';
@@ -61,7 +63,7 @@ Frame.prototype.toString = function () {
 
 module.exports.ServerFrame = {
     CONNECTED: function (session, identifier) { return Frame({ command: 'CONNECTED', header: { session: session, identifier: identifier } });  },
-    MESSAGE: function (distination, message_id, message) {return Frame( { command: 'MESSAGE', header: { destination: distination,'message-id': message_id }, body: message } ); },
+    MESSAGE: function (destination, message_id, message, subscription) {return Frame( { command: 'MESSAGE', header: { destination: destination, 'message-id': message_id, subscription: subscription }, body: message } ); },
     RECEIPT: function (receipt) { return Frame( { command: 'RECEIPT', header: { 'receipt-id': receipt } }); },
     ERROR: function (message, description) { return Frame( { command: 'ERROR', header: { message: message }, body: description }); }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
   ],
   "author": "Yaroslav Gaponov <yaroslav.gaponov@gmail.com>",
   "license": "BSD",
-  "dependencies": {},
+  "dependencies": {
+    "websocket": "^1.0.19"
+  },
   "devDependencies": {},
   "optionalDependencies": {
     "ldapauth": ">=2.1.1"

--- a/protocols/tcp.js
+++ b/protocols/tcp.js
@@ -1,0 +1,44 @@
+var net = require('net');
+var util = require('util');
+
+function createServer(broker, callbacks) {
+    return net.createServer(broker.serverOptions, function(socket) {            
+        socket.setEncoding('utf8');
+        socket.setKeepAlive(true);
+        
+        var remoteAddress = socket.address();
+        util.log(util.format('server is connected to %s:%s', remoteAddress.address, remoteAddress.port));
+        
+        var data = '';
+        socket.on('data', function(chunk) {
+            callbacks.debugDump(chunk);
+            
+            data += chunk.toString();
+            
+            var frames = data.split(stomp.DELIMETER);
+                            
+            if (frames.length > 1) {
+                data = frames.pop();                
+                frames.forEach(callbacks.frameReceived);
+            }
+        });
+        
+        socket.on('end', function() {
+            util.log(util.format('server is disconnected from %s:%s', remoteAddress.address, remoteAddress.port));
+            callbacks.disconnected(socket);
+        });
+    });
+}
+
+function sendMessage(socket, data) {
+    if (data) {
+        if (socket && socket.writable) {
+            socket.write(data.toString());
+        }
+    }
+}
+
+module.exports = {
+    createServer: createServer,
+    sendMessage: sendMessage
+}

--- a/protocols/websocket.js
+++ b/protocols/websocket.js
@@ -1,0 +1,57 @@
+var ws = require('websocket');
+var http = require('http');
+var util = require('util');
+
+function createServer(broker, callbacks) {
+    var server = http.createServer();
+
+    var wsServer = new ws.server({
+        httpServer: server,
+        autoAcceptConnections: true
+    });
+
+    wsServer.on('connect', function (webSocket) {
+        var socket = webSocket.socket;
+        
+        var remoteAddress = webSocket.socket.address();
+        util.log(util.format('websocket established to %s:%s', remoteAddress.address, remoteAddress.port));
+        
+        webSocket.on('message', function (message) {
+            callbacks.debugDump(message.utf8Data);
+            callbacks.frameReceived(message.utf8Data);
+        });
+        
+        webSocket.on('close', function() {
+            util.log(util.format('websocket to %s:%s terminated', remoteAddress.address, remoteAddress.port));
+            callbacks.disconnected(webSocket);
+        }.bind(this));
+    }.bind(this));
+
+    wsServer.listen = function() {
+        const server = this.config.httpServer[0];
+        return server.listen.apply(server, arguments);
+    }
+
+    wsServer.address = function() {
+        const tokens = this.config.httpServer[0]._connectionKey.split(':')
+
+        return {
+            port: tokens[2],
+            family: 'IPv'+tokens[0],
+            address: tokens[1]
+        }
+    }
+
+    return wsServer;
+}
+
+function sendMessage(socket, data) {
+    if(data) {
+        socket.sendUTF(data);
+    }
+}
+
+module.exports = {
+    createServer: createServer,
+    sendMessage: sendMessage
+}


### PR DESCRIPTION
The major change in 1.1 that I found lacking was the requirement for clients to generate a subscription id and for the server to include that id in stomp messages.

In order to not affect existing library users I have defaulted the protocol to 1.0 so that the new fields are not required.

I have moved web-callable methods into an object called commands so that the class may have function properties which cannot be accessed over the network. I have created a non-command version of send by which a user of the server may choose to directly message clients.

I have exposed the entire constructor through export as it makes instanceOf checks possible and allows users to extend the class.